### PR TITLE
fix invalid h265 codec string

### DIFF
--- a/src/remuxer/h265.js
+++ b/src/remuxer/h265.js
@@ -61,7 +61,7 @@ export class H265Remuxer extends BaseRemuxer {
         } else {
             this.remainingData = new Uint8Array();
         }
-    
+
         if (slices.length > 0) {
             this.remux(this.getVideoFrames(slices, duration, compositionTimeOffset));
             return true;
@@ -89,7 +89,7 @@ export class H265Remuxer extends BaseRemuxer {
 
         for (let nalu of nalus) {
             let unit = new NALU265(nalu);
-            
+
             if (!this.parseNAL(unit)) continue;
 
             // frame boundary detection
@@ -213,7 +213,7 @@ export class H265Remuxer extends BaseRemuxer {
 
     parseSPS(sps) {
         this.mp4track.sps = [new Uint8Array(sps)];
-        
+
         sps = H265Parser.removeEmulationPreventionBytes(sps);
         const config = H265Parser.readSPS(new Uint8Array(sps));
 
@@ -222,11 +222,10 @@ export class H265Remuxer extends BaseRemuxer {
         this.mp4track.height = config.height;
 
         this.mp4track.codec = 'hvc1'
-            + '.' + (config.profile_space ? String.fromCharCode(64 + config.profile_space) : '') // Map [0,1,2,3] to ['','A','B','C']
-            + config.profile_idc
-            + '.' + reverseBits(config.profile_compatibility_flags).toString(16)
-            + '.' + (config.tier_flag ? 'H' : 'L') + config.level_idc
-            + '.' + removeTrailingDotZero(config.constraint_indicator_flags.map(function (b) { return b.toString(16); }).join('.').toUpperCase());
+            + '.' + ((config.profile_space << 6) | (config.tier_flag << 5) | config.profile_idc)
+            + '.' + config.profile_compatibility_flags.toString(16).padStart(8, '0').toUpperCase()
+            + '.' + config.constraint_indicator_flags.map(function (b) { return b.toString(16).padStart(2, '0'); }).join('').toUpperCase()
+            + '.' + config.level_idc;
 
         this.mp4track.hvcC = {
             profile_space: config.profile_space,


### PR DESCRIPTION
The HEVC/H.265 remuxer generates an invalid codec string format that violates ISO/IEC 14496-15:2014 Annex E. This causes `MediaSource.addSourceBuffer()` to fail in browsers when attempting to play H.265 video streams.

For example, for a Main Profile, Main Tier, Level 5.0 stream with typical SPS parameters:
- profile_idc = 1
- profile_compatibility_flags = 0x60000000
- tier_flag = 0
- level_idc = 150
- constraint_indicator_flags = [0x90, 0x00, 0x00, 0x00, 0x00, 0x00]

The current code produces: `hvc1.1.6.L150.90.0.0.0.0.0`

The correct HEVC codec string format is:
```
hvc1.<O>.<B>.<C>.<L>
```

Where:
- **O** (general_profile_idc): `(profile_space << 6) | (tier_flag << 5) | profile_idc` as decimal
- **B** (profile_compatibility_flags): 32-bit value as 8-digit hex with leading zeros
- **C** (constraint_indicator_flags): 48-bit value as 12-digit hex with leading zeros
- **L** (level_idc): Decimal level value

For the example above, the correct output should be:
```
hvc1.1.60000000.900000000000.150
```